### PR TITLE
[PS-6258] Removing react-native Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "dependencies": {
     "lottie-react-native": "^2.6.0",
     "react": "16.8.3",
-    "react-native": "0.59.2",
     "react-native-gesture-handler": "^1.1.0",
     "react-native-largelist-v3": "^3.0.14",
     "react-native-spring-scrollview": "^2.0.21",


### PR DESCRIPTION
- Removing react-native as a dependency since hasteImpl crashes yarn thinking that there's a duplicate module name from this.
- Confirmed that Trophies V2 still works with this change by pointing our sdk-ota package.json to this branch and building/running again.